### PR TITLE
[CL][0000000] Fixed format issue with datepicker options hash

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "jquery-moving-service",
   "description": "client for https://github.com/RentPath/jquery-movingservice/",
   "main": "dist/jquery-moving-service.js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "dependencies": {
     "requirejs": "*",
     "jquery": "1.8.3",

--- a/dist/jquery-moving-service.js
+++ b/dist/jquery-moving-service.js
@@ -187,8 +187,8 @@
               city_from_selector.change();
               city_to_selector.change();
               $("#moving_lead_MovingDate").datepicker({
-                minDate: +3,
-                maxDate: "+6M",
+                minDate: "+2w",
+                maxDate: "+6m",
                 dateFormat: "mm/dd/yy"
               });
               $("#moving_lead_DayPhone").unmask().mask("(999) 999-9999");

--- a/dist/shared/jquery-moving-service.js
+++ b/dist/shared/jquery-moving-service.js
@@ -36,8 +36,8 @@
               city_from_selector.change();
               city_to_selector.change();
               $("#moving_lead_MovingDate").datepicker({
-                minDate: +3,
-                maxDate: "+6M",
+                minDate: "+2w",
+                maxDate: "+6m",
                 dateFormat: "mm/dd/yy"
               });
               $("#moving_lead_DayPhone").unmask().mask("(999) 999-9999");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-moving-service",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "dependencies": {},
   "devDependencies": {
     "coffee-script": "^1.9.1",

--- a/src/jquery-moving-service.coffee
+++ b/src/jquery-moving-service.coffee
@@ -35,8 +35,8 @@ define [
             city_from_selector.change()
             city_to_selector.change()
             $("#moving_lead_MovingDate").datepicker
-              minDate: +3
-              maxDate: "+6M"
+              minDate: "+2w"
+              maxDate: "+6m"
               dateFormat: "mm/dd/yy"
 
             $("#moving_lead_DayPhone").unmask().mask "(999) 999-9999"


### PR DESCRIPTION
## What I did

- datepicker minDate option accepts dates, integers or strings. Set minDate option to "+2w" as backend service requires lead to be at least 2 weeks away from the current date.
- updated bower.json, package.json

related documentation:
http://api.jqueryui.com/datepicker/#option-minDate