### PR TITLE
Revert "[TW][114426561] Fix package.json to work with npm"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,7 @@
 {
   "name": "jquery-moving-service",
   "version": "3.0.0",
-  "main": "jquery-moving-service.js",
   "dependencies": {},
-  "peerDependencies": {
-    "jquery": "^1.8.3",
-    "jquery-maskedinput": "^0.0.2",
-    "pikaday": "^1.4.0"
-  },
   "devDependencies": {
     "coffee-script": "^1.9.1",
     "grunt": "^0.4.5",


### PR DESCRIPTION
Reverts rentpath/jquery-moving-service.js#25

Going to revert this for now.  It's not required for npm, and has the potential to break code that still uses bower.  We'll need to decide how to handle npm dependencies going forward.